### PR TITLE
[normalise_aac] 0.0.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.7</span>**
+- add 'ac' parameter to ffmpeg command performing normalization to avoid unsupported channel layout error
+
 **<span style="color:#56adda">0.0.6</span>**
 - Update FFmpeg helper
 - Add platform declaration

--- a/info.json
+++ b/info.json
@@ -16,5 +16,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,ffmpeg,library file test",
-    "version": "0.0.6"
+    "version": "0.0.7"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -90,10 +90,11 @@ class PluginStreamMapper(StreamMapper):
         return False
 
     def custom_stream_mapping(self, stream_info: dict, stream_id: int):
+        channels = int(stream_info.get('channels'))
         return {
             'stream_mapping':  ['-map', '0:a:{}'.format(stream_id)],
             'stream_encoding': [
-                '-c:a:{}'.format(stream_id), 'aac',
+                '-c:a:{}'.format(stream_id), 'aac', '-ac:a:{}'.format(stream_id), '{}'.format(channels),
                 '-filter:a:{}'.format(stream_id), audio_filtergraph(self.settings),
             ]
         }


### PR DESCRIPTION
some users having issues with normalise plugin when stream missing a channel_layout ffprobe field and audio is 6 channels.  At least one user found issue when using encoder_audio_aac plugin to create aac from ac3.  Seems other users had same problem with files sourced from other than unmanic aac encoder plugin.

added `-ac` parameter to ffmpeg command which creates the proper channel layout for normalization to proceed.

Also adding similar to aac and ac3 encoders so audio streams created with proper channel layout.