### PR TITLE
Update audio_filtergraph() function in plugin.py

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -104,12 +104,14 @@ def audio_filtergraph(settings):
     i = settings.get_setting('I')
     if not i:
         i = settings.settings.get('I')
+
     lra = settings.get_setting('LRA')
     if not lra:
-        i = settings.settings.get('LRA')
+        lra = settings.settings.get('LRA')
+
     tp = settings.get_setting('TP')
     if not tp:
-        i = settings.settings.get('TP')
+        tp = settings.settings.get('TP')
 
     return 'loudnorm=I={}:LRA={}:TP={}'.format(i, lra, tp)
 


### PR DESCRIPTION
Fixes a bug where the plugin would fail if the max peak was set to 0.

[Parsed_loudnorm_0 @ 0x557654e98b80] Value -2.000000 for parameter 'I' out of range [-70 - -5]

The function accidentally sets I, LRA, or TP to the wrong variable (i) if they are missing. If any value is missing, it defaults to an incorrect assignment, causing I=-2.0, which is not valid.