### PR TITLE
Update custom_stream_mapping in plugin.py

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -93,10 +93,13 @@ class PluginStreamMapper(StreamMapper):
         channels = int(stream_info.get('channels'))
         return {
             'stream_mapping':  ['-map', '0:a:{}'.format(stream_id)],
+            original_sample_rate = stream_info.get('sample_rate', '48000')  # Default to 48kHz if not found
             'stream_encoding': [
                 '-c:a:{}'.format(stream_id), 'aac', '-ac:a:{}'.format(stream_id), '{}'.format(channels),
+                '-ar:a:{}'.format(stream_id), original_sample_rate,  # Use the original sample rate
                 '-filter:a:{}'.format(stream_id), audio_filtergraph(self.settings),
             ]
+
         }
 
 


### PR DESCRIPTION
Fixes bug where sample rates would be set to 96kHz

stream_info.get('sample_rate', '48000') retrieves the original sample rate from the input file.

If sample_rate is missing (unlikely but possible), it defaults to 48kHz as a fallback.

This ensures the AAC normalization process doesn’t change the sample rate unless necessary.