### PR TITLE
[normalise_aac] 0.0.9

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.9</span>**
+- fix in 0.0.8 had a bug where the original_sample_rate calculation was in the middle of the return values (moved it just above return stanza)
+
 **<span style="color:#56adda">0.0.8</span>**
 - Fixed a bug where the plugin would fail if the max peak was set to 0
 - Fixed bug where sample rates would be set to 96kHz

--- a/info.json
+++ b/info.json
@@ -16,5 +16,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,ffmpeg,library file test",
-    "version": "0.0.8"
+    "version": "0.0.9"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -91,15 +91,14 @@ class PluginStreamMapper(StreamMapper):
 
     def custom_stream_mapping(self, stream_info: dict, stream_id: int):
         channels = int(stream_info.get('channels'))
+        original_sample_rate = stream_info.get('sample_rate', '48000')  # Default to 48kHz if not found
         return {
             'stream_mapping':  ['-map', '0:a:{}'.format(stream_id)],
-            original_sample_rate = stream_info.get('sample_rate', '48000')  # Default to 48kHz if not found
             'stream_encoding': [
                 '-c:a:{}'.format(stream_id), 'aac', '-ac:a:{}'.format(stream_id), '{}'.format(channels),
                 '-ar:a:{}'.format(stream_id), original_sample_rate,  # Use the original sample rate
                 '-filter:a:{}'.format(stream_id), audio_filtergraph(self.settings),
             ]
-
         }
 
 


### PR DESCRIPTION
the original_sample_rate calculation line was in the middle of the return values (between stream_mapping and stream_encoding) and was causing an error rendering the plugin unable to run.  i relocated the line to just before the return stanza, which references the original_sample_rate variable.